### PR TITLE
Create GDG Liverpool

### DIFF
--- a/_data/groups/GDG Liverpool.yml
+++ b/_data/groups/GDG Liverpool.yml
@@ -1,0 +1,9 @@
+	"name": "GDG Liverpool",
+    	"description": "Google Developer Group (GDG) Liverpool is a meetup for Developer enthusiasts in the local community. Focusing primarily on Android and Google technology. Join us for demos, talks and discussions of new technologies, followed by a social - To meet other like minded professionals, and to learn and support one another. Disclaimer: Google Developer Group Liverpool is an independent group; our activities and the opinions expressed here should in no way be linked to Google, the corporation.",
+    	"organiser": "Niamh Power and Joe Timmins",
+    	"email": "joe@novoda.com",
+    	"where": "Liverpool",
+    	"when": "Approximately every 2 months",
+    	"twitter": "@gdg_liverpool",
+    	"website": "https://www.meetup.com/GDG-Liverpool/",
+    	"advertised": "Meetup, Twitter, word of mouth"	 


### PR DESCRIPTION
This PR adds details for our Google Developer Group meetup in Liverpool.