### PR TITLE
Replaced broken images with semantic-ui ones

### DIFF
--- a/calendar.md
+++ b/calendar.md
@@ -4,6 +4,6 @@ redirect_from: index.html
 ---
 This is a public calendar. Feel free to use! Kept up to date by the organisers of the listed events.
 
-<a href="https://www.google.com/calendar/feeds/a73q3trj8bssqjifgolb1q8fr4%40group.calendar.google.com/public/basic" target="_blank"><img src="https://www.google.com/calendar/images/xml.gif" alt="" /></a>&nbsp;<a href="https://www.google.com/calendar/ical/a73q3trj8bssqjifgolb1q8fr4%40group.calendar.google.com/public/basic.ics" target="_blank"><img src="https://www.google.com/calendar/images/ical.gif" alt="" /></a>&nbsp;<a href="https://www.google.com/calendar/embed?src=a73q3trj8bssqjifgolb1q8fr4%40group.calendar.google.com&amp;ctz=Europe/London" target="_blank"><img src="https://www.google.com/calendar/images/html.gif" alt="" /></a>
+<a href="https://www.google.com/calendar/ical/a73q3trj8bssqjifgolb1q8fr4%40group.calendar.google.com/public/basic.ics" target="_blank"><i class="calendar plus outline icon"></i></a>&nbsp;<a href="https://www.google.com/calendar/embed?src=a73q3trj8bssqjifgolb1q8fr4%40group.calendar.google.com&amp;ctz=Europe/London" target="_blank"><i class="calendar plus outline icon"></i></a>
 <iframe src="https://www.google.com/calendar/embed?showTitle=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=a73q3trj8bssqjifgolb1q8fr4%40group.calendar.google.com&amp;color=%23B1440E&amp;ctz=Europe%2FLondon" style=" border-width:0 " width="100%" height="600" frameborder="0" scrolling="no"></iframe>
 

--- a/calendar.md
+++ b/calendar.md
@@ -4,6 +4,7 @@ redirect_from: index.html
 ---
 This is a public calendar. Feel free to use! Kept up to date by the organisers of the listed events.
 
-<a href="https://www.google.com/calendar/ical/a73q3trj8bssqjifgolb1q8fr4%40group.calendar.google.com/public/basic.ics" target="_blank"><i class="calendar plus outline icon"></i></a>&nbsp;<a href="https://www.google.com/calendar/embed?src=a73q3trj8bssqjifgolb1q8fr4%40group.calendar.google.com&amp;ctz=Europe/London" target="_blank"><i class="calendar plus outline icon"></i></a>
+<a href="https://www.google.com/calendar/ical/a73q3trj8bssqjifgolb1q8fr4%40group.calendar.google.com/public/basic.ics" target="_blank"><i class="calendar plus outline icon" data-content="Add the ical Calendar Feed to your own calendar." data-variation="very wide"></i></a>
+<a href="https://www.google.com/calendar/embed?src=a73q3trj8bssqjifgolb1q8fr4%40group.calendar.google.com&amp;ctz=Europe/London" target="_blank"><i class="calendar plus outline icon" data-content="Open the Calendar in your browser." data-variation="very wide"></i></a>
 <iframe src="https://www.google.com/calendar/embed?showTitle=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=a73q3trj8bssqjifgolb1q8fr4%40group.calendar.google.com&amp;color=%23B1440E&amp;ctz=Europe%2FLondon" style=" border-width:0 " width="100%" height="600" frameborder="0" scrolling="no"></iframe>
 


### PR DESCRIPTION
This change replaces the broken "Add XML", "Add ICAL" and "View Calendar" buttons with a single "Add Calendar" icon (as the XML calendar isn't used anywhere, I think!) and "Calendar" icon.